### PR TITLE
Client can receive body content as an array and display the content in sections

### DIFF
--- a/cypress/fixtures/experiencesList.json
+++ b/cypress/fixtures/experiencesList.json
@@ -1,34 +1,44 @@
 {
   "articles": [
       {
-          "id": 15,
+          "id": 10,
           "title": "Experience Test 5",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-          "date": "2021-03-03"
+          "article_type": "experience",
+          "category": "food",
+          "date": "2021-03-07"
       },
       {
-          "id": 14,
+          "id": 9,
           "title": "Experience Test 4",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-          "date": "2021-03-03"
+          "article_type": "experience",
+          "category": "trip",
+          "date": "2021-03-07"
       },
       {
-          "id": 13,
+          "id": 8,
           "title": "Experience Test 3",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-          "date": "2021-03-03"
+          "article_type": "experience",
+          "category": "food",
+          "date": "2021-03-07"
       },
       {
-          "id": 12,
+          "id": 7,
           "title": "Experience Test 2",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-          "date": "2021-03-03"
+          "article_type": "experience",
+          "category": "trip",
+          "date": "2021-03-07"
       },
       {
-          "id": 11,
+          "id": 6,
           "title": "Experience Test 1",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-          "date": "2021-03-03"
+          "article_type": "experience",
+          "category": "food",
+          "date": "2021-03-07"
       }
   ]
 }

--- a/cypress/fixtures/locationList.json
+++ b/cypress/fixtures/locationList.json
@@ -5,42 +5,48 @@
           "title": "Experience Test 5",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "food",
+          "date": "2021-03-07"
       },
       {
           "id": 9,
           "title": "Experience Test 4",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "trip",
+          "date": "2021-03-07"
       },
       {
           "id": 8,
           "title": "Experience Test 3",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "food",
+          "date": "2021-03-07"
       },
       {
           "id": 5,
           "title": "Story Test 5",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "news",
+          "date": "2021-03-07"
       },
       {
           "id": 4,
           "title": "Story Test 4",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "event",
+          "date": "2021-03-07"
       },
       {
           "id": 3,
           "title": "Story Test 3",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "event",
+          "date": "2021-03-07"
       }
   ],
   "message": "Latest articles from Frederiksdal"

--- a/cypress/fixtures/locationNoArticles.json
+++ b/cypress/fixtures/locationNoArticles.json
@@ -5,70 +5,80 @@
           "title": "Experience Test 5",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "food",
+          "date": "2021-03-07"
       },
       {
           "id": 9,
           "title": "Experience Test 4",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "trip",
+          "date": "2021-03-07"
       },
       {
           "id": 8,
           "title": "Experience Test 3",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "food",
+          "date": "2021-03-07"
       },
       {
           "id": 7,
           "title": "Experience Test 2",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "trip",
+          "date": "2021-03-07"
       },
       {
           "id": 6,
           "title": "Experience Test 1",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "food",
+          "date": "2021-03-07"
       },
       {
           "id": 5,
           "title": "Story Test 5",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "news",
+          "date": "2021-03-07"
       },
       {
           "id": 4,
           "title": "Story Test 4",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "event",
+          "date": "2021-03-07"
       },
       {
           "id": 3,
           "title": "Story Test 3",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "event",
+          "date": "2021-03-07"
       },
       {
           "id": 2,
           "title": "Story Test 2",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "news",
+          "date": "2021-03-07"
       },
       {
           "id": 1,
           "title": "Story Test 1",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "event",
+          "date": "2021-03-07"
       }
   ],
   "message": "We found no local articles from Dreetz."

--- a/cypress/fixtures/noLocationList.json
+++ b/cypress/fixtures/noLocationList.json
@@ -5,70 +5,80 @@
           "title": "Experience Test 5",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "food",
+          "date": "2021-03-07"
       },
       {
           "id": 9,
           "title": "Experience Test 4",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "trip",
+          "date": "2021-03-07"
       },
       {
           "id": 8,
           "title": "Experience Test 3",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "food",
+          "date": "2021-03-07"
       },
       {
           "id": 7,
           "title": "Experience Test 2",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "trip",
+          "date": "2021-03-07"
       },
       {
           "id": 6,
           "title": "Experience Test 1",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "experience",
-          "date": "2021-03-05"
+          "category": "food",
+          "date": "2021-03-07"
       },
       {
           "id": 5,
           "title": "Story Test 5",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "news",
+          "date": "2021-03-07"
       },
       {
           "id": 4,
           "title": "Story Test 4",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "event",
+          "date": "2021-03-07"
       },
       {
           "id": 3,
           "title": "Story Test 3",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "event",
+          "date": "2021-03-07"
       },
       {
           "id": 2,
           "title": "Story Test 2",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "news",
+          "date": "2021-03-07"
       },
       {
           "id": 1,
           "title": "Story Test 1",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
           "article_type": "story",
-          "date": "2021-03-05"
+          "category": "event",
+          "date": "2021-03-07"
       }
   ],
   "message": "We weren't able to get your location. Enjoy our latest articles instead!"

--- a/cypress/fixtures/singleArticle.json
+++ b/cypress/fixtures/singleArticle.json
@@ -3,7 +3,12 @@
       "id": 2,
       "title": "Story Test 2",
       "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-      "body": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Dui accumsan sit amet nulla facilisi. Fringilla est ullamcorper eget nulla facilisi etiam. Et tortor consequat id porta nibh venenatis cras sed felis. Arcu dui vivamus arcu felis. Vitae semper quis lectus nulla at. Neque vitae tempus quam pellentesque nec nam. Adipiscing at in tellus integer feugiat scelerisque varius morbi enim. A iaculis at erat pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at.",
-      "date": "2021-03-03"
+      "body": [
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Dui accumsan sit amet nulla facilisi. Fringilla est ullamcorper eget nulla facilisi etiam. Et tortor consequat id porta nibh venenatis cras sed felis. Arcu dui vivamus arcu felis. Vitae semper quis lectus nulla at. Neque vitae tempus quam pellentesque nec nam. Adipiscing at in tellus integer feugiat scelerisque varius morbi enim. A iaculis at erat pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at.",
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Dui accumsan sit amet nulla facilisi. Fringilla est ullamcorper eget nulla facilisi etiam. Et tortor consequat id porta nibh venenatis cras sed felis. Arcu dui vivamus arcu felis. Vitae semper quis lectus nulla at. Neque vitae tempus quam pellentesque nec nam. Adipiscing at in tellus integer feugiat scelerisque varius morbi enim. A iaculis at erat pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at."
+      ],
+      "category": "news",
+      "location": "Gothenburg",
+      "date": "2021-03-07"
   }
 }

--- a/cypress/fixtures/storiesList.json
+++ b/cypress/fixtures/storiesList.json
@@ -4,31 +4,41 @@
           "id": 5,
           "title": "Story Test 5",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-          "date": "2021-03-03"
+          "article_type": "story",
+          "category": "news",
+          "date": "2021-03-07"
       },
       {
           "id": 4,
           "title": "Story Test 4",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-          "date": "2021-03-03"
+          "article_type": "story",
+          "category": "event",
+          "date": "2021-03-07"
       },
       {
           "id": 3,
           "title": "Story Test 3",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-          "date": "2021-03-03"
+          "article_type": "story",
+          "category": "event",
+          "date": "2021-03-07"
       },
       {
           "id": 2,
           "title": "Story Test 2",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-          "date": "2021-03-03"
+          "article_type": "story",
+          "category": "news",
+          "date": "2021-03-07"
       },
       {
           "id": 1,
           "title": "Story Test 1",
           "teaser": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-          "date": "2021-03-03"
+          "article_type": "story",
+          "category": "event",
+          "date": "2021-03-07"
       }
   ]
 }

--- a/cypress/integration/DisplaysALocationBasedFrontPage.feature.js
+++ b/cypress/integration/DisplaysALocationBasedFrontPage.feature.js
@@ -36,7 +36,7 @@ describe('Front page displays articles based on location', () => {
       cy.get('[data-cy="experience-wrapper"]').within(() => {
         cy.get('[data-id="article-item-1"]').within(() => {
           cy.get('[data-cy="title"]').should('contain', 'Experience Test 5')
-          cy.get('[data-cy="date"]').should('contain', 'Published on: 2021-03-05')
+          cy.get('[data-cy="date"]').should('contain', 'Published on: 2021-03-07')
           cy.get('[data-cy="teaser"]').should('contain', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')
         })
       })
@@ -51,7 +51,7 @@ describe('Front page displays articles based on location', () => {
       cy.get('[data-cy="story-wrapper"]').within(() => {
         cy.get('[data-id="article-item-1"]').within(() => {
           cy.get('[data-cy="title"]').should('contain', 'Story Test 5')
-          cy.get('[data-cy="date"]').should('contain', 'Published on: 2021-03-05')
+          cy.get('[data-cy="date"]').should('contain', 'Published on: 2021-03-07')
           cy.get('[data-cy="teaser"]').should('contain', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')
         })
       })

--- a/cypress/integration/DisplaysListOfExperiences.feature.js
+++ b/cypress/integration/DisplaysListOfExperiences.feature.js
@@ -35,7 +35,7 @@ describe('Displays list of experience articles', () => {
         cy.get('[data-id="article-item-1"]').within(() => {
           cy.get('[data-cy="title"]').should('contain', 'Experience Test 5')
           cy.get('[data-cy="teaser"]').should('contain', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')
-          cy.get('[data-cy="date"]').should('contain', 'Published on: 2021-03-03')
+          cy.get('[data-cy="date"]').should('contain', 'Published on: 2021-03-07')
         })
       })
     })

--- a/cypress/integration/DisplaysListOfStories.feature.js
+++ b/cypress/integration/DisplaysListOfStories.feature.js
@@ -29,7 +29,7 @@ describe('Displays list of story articles', () => {
         cy.get('[data-id="article-item-1"]').within(() => {
           cy.get('[data-cy="title"]').should('contain', 'Story Test 5')
           cy.get('[data-cy="teaser"]').should('contain', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')
-          cy.get('[data-cy="date"]').should('contain', 'Published on: 2021-03-03')
+          cy.get('[data-cy="date"]').should('contain', 'Published on: 2021-03-07')
         })
       })
     })

--- a/cypress/integration/DisplaysSingleArticle.feature.js
+++ b/cypress/integration/DisplaysSingleArticle.feature.js
@@ -24,7 +24,7 @@ describe('client displays single article', () => {
 
     it('displays expected content', () => {
       cy.get('[data-cy="article-header"]').should('contain', 'Story Test 2')
-      cy.get('[data-cy="article-meta"]').should('contain', 'Published: 2021-03-03')
+      cy.get('[data-cy="article-meta"]').should('contain', 'Published: 2021-03-07')
       cy.get('[data-cy="article-teaser"]').should('contain', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')
       cy.get('[data-cy="article-body"]').should('contain', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Dui accumsan sit amet nulla facilisi. Fringilla est ullamcorper eget nulla facilisi etiam. Et tortor consequat id porta nibh venenatis cras sed felis. Arcu dui vivamus arcu felis. Vitae semper quis lectus nulla at. Neque vitae tempus quam pellentesque nec nam. Adipiscing at in tellus integer feugiat scelerisque varius morbi enim. A iaculis at erat pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at.')
     })

--- a/src/components/SingleArticle.jsx
+++ b/src/components/SingleArticle.jsx
@@ -14,6 +14,15 @@ const SingleArticle = () => {
     getSingleArticle(id)
   }, [id])
 
+  let contentList
+  if (content.body) {
+    contentList = content.body.map(paragraph => {
+      return (
+        <p>{paragraph}</p>
+      )
+    })
+  }
+
   return (
     <Grid className="main-view">
       <Container textAlign="left" text>
@@ -29,7 +38,7 @@ const SingleArticle = () => {
                 </Header.Subheader>
                 <Header as="h4" data-cy="article-teaser">{content.teaser}</Header>
               </Header>
-              <p data-cy="article-body">{content.body}</p>
+              <p data-cy="article-body">{contentList}</p>
             </>
           ) : (
               <>


### PR DESCRIPTION
[**PT-Story:**  ](https://www.pivotaltracker.com/story/show/177234338)
### User Story 
``` 
As a visitor
In order to read the articles more easily
I want the content to be sectionized
``` 
## Changes proposed in this pull request: 
* Updates fixtures with up to date responses
* Adds a map function to SingleArticle in order to display the body content in sections
## What I have learned working on this feature: 
* A little bit of Regex
## Screenshots (Client) 
![Screenshot from 2021-03-07 15-29-18](https://user-images.githubusercontent.com/75306727/110243262-e8d4a900-7f59-11eb-9d4d-3135ba1fa8d0.png)
