### PR TITLE
Client shows images with the articles

### DIFF
--- a/cypress/integration/DisplaysALocationBasedFrontPage.feature.js
+++ b/cypress/integration/DisplaysALocationBasedFrontPage.feature.js
@@ -27,15 +27,24 @@ describe('Front page displays articles based on location', () => {
       cy.get('[data-cy="your-location"]').should('contain', 'Latest articles from Frederiksdal')
     })
 
+    it('displays a hero section', () => {
+      cy.get('[data-cy="hero-item"]').within(() => {
+        cy.get('[data-cy="hero-img"]').should('exist')
+        cy.get('[data-cy="hero-title"]').should('contain', 'Experience Test 5')
+        cy.get('[data-cy="hero-date"]').should('contain', 'Published on: 2021-03-09')
+        cy.get('[data-cy="hero-teaser"]').should('contain','Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')
+      })
+    })
+
     it('displays a list of experience articles', () => {
       cy.get('[data-cy="experience-wrapper"]')
-        .find('[data-cy="article-item"]').should('have.length', 3)
+        .find('[data-cy="article-item"]').should('have.length', 2)
     })
 
     it('displays the right content in experiences list', () => {
       cy.get('[data-cy="experience-wrapper"]').within(() => {
         cy.get('[data-id="article-item-1"]').within(() => {
-          cy.get('[data-cy="title"]').should('contain', 'Experience Test 5')
+          cy.get('[data-cy="title"]').should('contain', 'Experience Test 4')
           cy.get('[data-cy="date"]').should('contain', 'Published on: 2021-03-09')
           cy.get('[data-cy="teaser"]').should('contain', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')
         })
@@ -88,7 +97,7 @@ describe('Front page displays articles based on location', () => {
 
     it('still displays a list of experience articles', () => {
       cy.get('[data-cy="experience-wrapper"]')
-        .find('[data-cy="article-item"]').should('have.length', 5)
+        .find('[data-cy="article-item"]').should('have.length', 4)
     })
   })
   describe('unsuccessfully with no articles from the given location', () => {
@@ -127,7 +136,7 @@ describe('Front page displays articles based on location', () => {
 
     it('still displays a list of experience articles', () => {
       cy.get('[data-cy="experience-wrapper"]')
-        .find('[data-cy="article-item"]').should('have.length', 5)
+        .find('[data-cy="article-item"]').should('have.length', 4)
     })
   })
 })

--- a/src/app.css
+++ b/src/app.css
@@ -9,6 +9,15 @@
   padding-left: 10px;
 }
 
+.ui.fluid.card {
+  transform: none!important;
+}
+
+.hero-img {
+  height: 300px!important;
+  object-fit: cover;
+}
+
 .main-story {
   margin-top: 33px!important;
 }

--- a/src/components/ArticleList.jsx
+++ b/src/components/ArticleList.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Item } from 'semantic-ui-react'
+import { Item, Image } from 'semantic-ui-react'
 import { Link } from 'react-router-dom'
 
 const ArticleList = ({ articles }) => {
@@ -9,6 +9,7 @@ const ArticleList = ({ articles }) => {
     articleList = articles.map((article, i) => {
       return (
         <Item as={Link} to={`articles/${article.id}`} data-cy="article-item" data-id={`article-item-${i + 1}`} key={i + 1} >
+          <Image size="small" alt="article-image" src={article.image} style={{objectFit: 'cover'}}/>
           <Item.Content>
             <Item.Header data-cy="title">{article.title}</Item.Header>
             <Item.Meta data-cy="date">Published on: {article.date}</Item.Meta>

--- a/src/components/HeroArticle.jsx
+++ b/src/components/HeroArticle.jsx
@@ -6,13 +6,13 @@ const HeroArticle = ({ article }) => {
 
   return (
     <>
-      { article[0] &&
-        <Card fluid data-cy="hero-item" as={Link} to={`articles/${article[0].id}`}>
-          <Image fluid data-cy="hero-img" className="hero-img" alt="hero-image" src={article[0].image} />
+      { article &&
+        <Card fluid data-cy="hero-item" as={Link} to={`articles/${article.id}`}>
+          <Image fluid data-cy="hero-img" className="hero-img" alt="hero-image" src={article.image} />
           <Card.Content>
-            <Card.Header data-cy="hero-title" size="large">{article[0].title}</Card.Header>
-            <Card.Description data-cy="hero-date">Published on: {article[0].date}</Card.Description>
-            <Header data-cy="hero-teaser" size="small">{article[0].teaser}</Header >
+            <Card.Header data-cy="hero-title" size="large">{article.title}</Card.Header>
+            <Card.Description data-cy="hero-date">Published on: {article.date}</Card.Description>
+            <Header data-cy="hero-teaser" size="small">{article.teaser}</Header >
           </Card.Content>
         </Card>
       }

--- a/src/components/HeroArticle.jsx
+++ b/src/components/HeroArticle.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { Image, Card, Header } from 'semantic-ui-react'
+
+const HeroArticle = ({ article }) => {
+
+  return (
+    <>
+      { article[0] &&
+        <Card fluid data-cy="hero-item" as={Link} to={`articles/${article[0].id}`}>
+          <Image fluid data-cy="hero-img" className="hero-img" alt="hero-image" src={article[0].image} />
+          <Card.Content>
+            <Card.Header data-cy="hero-title" size="large">{article[0].title}</Card.Header>
+            <Card.Description data-cy="hero-date">Published on: {article[0].date}</Card.Description>
+            <Header data-cy="hero-teaser" size="small">{article[0].teaser}</Header >
+          </Card.Content>
+        </Card>
+      }
+    </>
+  )
+}
+
+export default HeroArticle

--- a/src/components/SingleArticle.jsx
+++ b/src/components/SingleArticle.jsx
@@ -36,7 +36,7 @@ const SingleArticle = () => {
                   <br />
                   Category: {content.category}
                   <br />
-                  Author: {content.author.name}
+                  {content.author && `Author: ${content.author.name}`}
                 </Header.Subheader>
               </Header>
               <Image alt="article-image" src={content.image}/>

--- a/src/components/SingleArticle.jsx
+++ b/src/components/SingleArticle.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Container, Header, Segment, Button, Grid } from 'semantic-ui-react'
+import { Container, Header, Segment, Button, Grid, Image } from 'semantic-ui-react'
 import { useSelector } from 'react-redux'
 import { useParams, useHistory } from 'react-router-dom'
 import { getSingleArticle } from '../modules/articlesDataModule'
@@ -35,9 +35,12 @@ const SingleArticle = () => {
                   Published: {content.date}
                   <br />
                   Category: {content.category}
+                  <br />
+                  Author: {content.author.name}
                 </Header.Subheader>
-                <Header as="h4" data-cy="article-teaser">{content.teaser}</Header>
               </Header>
+              <Image alt="article-image" src={content.image}/>
+              <Header as="h4" data-cy="article-teaser">{content.teaser}</Header>
               <p data-cy="article-body">{contentList}</p>
             </>
           ) : (

--- a/src/views/Explore.jsx
+++ b/src/views/Explore.jsx
@@ -35,23 +35,23 @@ const Explore = () => {
     <Grid className="main-view">
       <Grid.Row centered textAlign="center">
         <Header className="main-header" data-cy="explore-header">
-          <Icon circular name="map signs" size="tiny" />
+          <Icon circular name="map signs" color="blue" size="tiny" />
           <Header.Content>Explore</Header.Content>
         </Header>
       </Grid.Row>
       <Grid.Row centered>
-        <Button size="huge" color="blue" data-cy="story-button" onClick={() => {
+        <Button size="large" color="blue" data-cy="story-button" onClick={() => {
           store.dispatch({ type: "SET_ARTICLE_TYPE", payload: 'story' })
           switchHeader('story')
         }}>Stories</Button>
-        <Button size="huge" color="blue" data-cy="experience-button" onClick={() => {
+        <Button size="large" color="blue" data-cy="experience-button" onClick={() => {
           store.dispatch({ type: "SET_ARTICLE_TYPE", payload: 'experience' })
           switchHeader('experience')
         }}>Experiences</Button>
       </Grid.Row>
       <Grid.Row centered>
         <Segment.Group>
-          <Segment>
+          <Segment attached="top">
             <Button data-cy="event-category-button" onClick={() => {
               getByCategory('event')
               switchHeader('event')

--- a/src/views/GetLocal.jsx
+++ b/src/views/GetLocal.jsx
@@ -21,7 +21,7 @@ const GetLocal = () => {
           Experiences
           <Header.Subheader data-cy="your-location">{message}</Header.Subheader>
         </Header>
-        <HeroArticle article={experienceArticles.slice(0,1)} />
+        <HeroArticle article={experienceArticles[0]} />
         <Item.Group divided data-cy="experience-wrapper">
           <ArticleList articles={experienceArticles.slice(1)} />
         </Item.Group>

--- a/src/views/GetLocal.jsx
+++ b/src/views/GetLocal.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import { Grid, Item, Header } from 'semantic-ui-react'
 import ArticleList from '../components/ArticleList'
+import HeroArticle from '../components/HeroArticle'
 import { getLocationArticles } from '../modules/articlesDataModule'
 import { useSelector } from 'react-redux'
 
@@ -9,7 +10,6 @@ const GetLocal = () => {
   const { message } = useSelector(state => state)
   const experienceArticles = articles.filter(article => article.article_type === 'experience')
   const storyArticles = articles.filter(article => article.article_type === 'story')
-
   useEffect(() => {
     getLocationArticles()
   }, [])
@@ -21,13 +21,14 @@ const GetLocal = () => {
           Experiences
           <Header.Subheader data-cy="your-location">{message}</Header.Subheader>
         </Header>
-        <Item.Group data-cy="experience-wrapper">
-          <ArticleList articles={experienceArticles} />
+        <HeroArticle article={experienceArticles.slice(0,1)} />
+        <Item.Group divided data-cy="experience-wrapper">
+          <ArticleList articles={experienceArticles.slice(1)} />
         </Item.Group>
       </Grid.Column>
-      <Grid.Column textAlign="center" width={6}>
-        <Header dividing className="sub-header main-story">Stories</Header>
-        <Item.Group data-cy="story-wrapper">
+      <Grid.Column  width={6}>
+        <Header textAlign="center" dividing className="sub-header main-story">Stories</Header>
+        <Item.Group divided data-cy="story-wrapper">
           <ArticleList articles={storyArticles} />
         </Item.Group>
       </Grid.Column>


### PR DESCRIPTION
[**PT-Story:**  ](https://www.pivotaltracker.com/story/show/177245434)
### User Story 
``` 
As a visitor
In order to have a visual experience
I would like to see images with the articles
``` 
## Changes proposed in this pull request: 
* Adds thumbnail images to all lists
* Adds hero section to Get Local view
* Adds image to SingleArticle
## Screenshots (Client) 
![Screenshot from 2021-03-09 23-22-19](https://user-images.githubusercontent.com/75306727/110546206-7c5ed300-812e-11eb-968f-e682578f810f.png)
